### PR TITLE
32 bit changed to 32-bit (hyphen in between)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ hubot>>
 2016-01-18 by pklinger
 
 Today's tip is about performance. Ever came across the double tilde ~~ operator? It is sometimes also called the double NOT bitwise operator. You can use it as a faster substitute for Math.floor(). Why is that?
-One bitwise shift ~ transforms the 32 bit converted input into -(input+1). The double bitwise shift therefore transforms the input into -(-(input + 1)+1) making it a great tool to round towards 0. For numeric input, it therefore mimics the Math.ceil() for negative and Math.floor() for positive input. On failure, 0 is being returned, which might come in handy sometimes instead of Math.floor() return value NaN on failure.
+One bitwise shift ~ transforms the 32-bit converted input into -(input+1). The double bitwise shift therefore transforms the input into -(-(input + 1)+1) making it a great tool to round towards 0. For numeric input, it therefore mimics the Math.ceil() for negative and Math.floor() for positive input. On failure, 0 is being returned, which might come in handy sometimes instead of Math.floor() return value NaN on failure.
 // single ~
 console.log(~1337)    // -1338
 


### PR DESCRIPTION
Use a hyphen to link numbers to the noun that comes after them when they constitute the initial part of a compound adjective.
The reader will understand that both words work together to modify another noun in this manner. This holds true regardless of whether the number is expressed in words or digits.